### PR TITLE
Add shape keyword to solvers

### DIFF
--- a/src/CGNR.jl
+++ b/src/CGNR.jl
@@ -1,8 +1,9 @@
 export cgnr, CGNR
 
-mutable struct CGNR{matT,opT,vecT,T,R,PR} <: AbstractKrylovSolver
+mutable struct CGNR{matT,opT, N,vecT,T,R,PR} <: AbstractKrylovSolver
   A::matT
   AHA::opT
+  shape::NTuple{N, Int64}
   L2::R
   constr::PR
   x::vecT
@@ -49,6 +50,7 @@ function CGNR(A
             , weights::AbstractVector = similar(AHA, 0)
             , iterations::Int = 10
             , relTol::Real = eps(real(eltype(AHA)))
+            , shape = (size(AHA, 2),)
             )
 
   T = eltype(AHA)
@@ -82,7 +84,7 @@ function CGNR(A
   other = identity.(other)
 
 
-  return CGNR(A, AHA,
+  return CGNR(A, AHA, shape, 
     L2, other, x, x₀, pl, vl, αl, βl, ζl, weights, iterations, relTol, 0.0, normalizeReg)
 end
 
@@ -134,7 +136,7 @@ performs one CGNR iteration.
 function iterate(solver::CGNR, iteration::Int=0)
   if done(solver, iteration)
     for r in solver.constr
-      prox!(r, solver.x)
+      prox!(r, reshape(solver.x, solver.shape))
     end
     return nothing
   end

--- a/src/DAXConstrained.jl
+++ b/src/DAXConstrained.jl
@@ -1,7 +1,8 @@
 export DaxConstrained
 
-mutable struct DaxConstrained{matT,T,Tsparse,U} <: AbstractRowActionSolver
+mutable struct DaxConstrained{matT,N,T,Tsparse,U} <: AbstractRowActionSolver
   A::matT
+  shape::NTuple{N, Int64}
   u::Vector{T}
   λ::Float64
   B::Tsparse
@@ -49,6 +50,7 @@ function DaxConstrained(A
                       , sparseTrafo=nothing
                       , iterations::Int=3
                       , iterationsInner::Int=2
+                      , shape = (size(A, 1),)
                       )
 
   T = eltype(A)
@@ -79,7 +81,7 @@ function DaxConstrained(A
   τl = zero(T)
   αl = zero(T)
 
-  return DaxConstrained(A,u,Float64(λ),B,Bnorm²,denom,rowindex,x,bk,bc,xl,yl,yc,δc,εw,τl,αl
+  return DaxConstrained(A,shape,u,Float64(λ),B,Bnorm²,denom,rowindex,x,bk,bc,xl,yl,yc,δc,εw,τl,αl
                   ,rT.(weights),iterations,iterationsInner)
 end
 

--- a/src/Kaczmarz.jl
+++ b/src/Kaczmarz.jl
@@ -1,8 +1,9 @@
 export kaczmarz
 export Kaczmarz
 
-mutable struct Kaczmarz{matT,T,U,R,RN} <: AbstractRowActionSolver
+mutable struct Kaczmarz{matT,N,T,U,R,RN} <: AbstractRowActionSolver
   A::matT
+  shape::NTuple{N, Int64}
   u::Vector{T}
   L2::R
   reg::Vector{RN}
@@ -55,6 +56,7 @@ function Kaczmarz(A
                 , seed::Int = 1234
                 , iterations::Int = 10
                 , regMatrix = nothing
+                , shape = (size(A, 1),)
                 )
 
   T = real(eltype(A))
@@ -105,7 +107,7 @@ function Kaczmarz(A
   τl = zero(eltype(A))
   αl = zero(eltype(A))
 
-  return Kaczmarz(A, u, L2, other, denom, rowindex, rowIndexCycle, x, vl, εw, τl, αl,
+  return Kaczmarz(A, shape, u, L2, other, denom, rowindex, rowIndexCycle, x, vl, εw, τl, αl,
                   T.(w), randomized, subMatrixSize, probabilities, shuffleRows,
                   Int64(seed), iterations, regMatrix,
                   normalizeReg)
@@ -167,7 +169,7 @@ function iterate(solver::Kaczmarz, iteration::Int=0)
   end
 
   for r in solver.reg
-    prox!(r, solver.x)
+    prox!(r, reshape(solver.x, solver.shape))
   end
 
   return solver.vl, iteration+1

--- a/src/Regularization/MaskedRegularization.jl
+++ b/src/Regularization/MaskedRegularization.jl
@@ -21,7 +21,7 @@ julia> prox!(masked, fill(-1, 4))
 """
 struct MaskedRegularization{S, R<:AbstractRegularization} <: AbstractNestedRegularization{S}
   reg::R
-  mask::Vector{Bool}
+  mask::AbstractArray{Bool}
   MaskedRegularization(reg::R, mask) where R <: AbstractRegularization = new{R, R}(reg, mask)
   MaskedRegularization(reg::R, mask) where {S, R<:AbstractNestedRegularization{S}} = new{S,R}(reg, mask)
 end
@@ -29,12 +29,12 @@ innerreg(reg::MaskedRegularization) = reg.reg
 
 
 function prox!(reg::MaskedRegularization, x::AbstractArray, args...)
-	z = view(x, findall(reg.mask))
+	z = view(x, reg.mask)
   prox!(reg.reg, z, args...)
 	return x
 end
 function norm(reg::MaskedRegularization, x::AbstractArray, args...)
-  z = view(x, findall(reg.mask))
+  z = view(x, reg.mask)
   result = norm(reg.reg, z, args...)
   return result
 end

--- a/src/Regularization/NestedRegularization.jl
+++ b/src/Regularization/NestedRegularization.jl
@@ -26,5 +26,5 @@ sinktype(::AbstractNestedRegularization{S}) where S = S
 prox!(reg::AbstractNestedRegularization{S}, x) where S <: AbstractParameterizedRegularization = prox!(reg, x, λ(reg))
 norm(reg::AbstractNestedRegularization{S}, x) where S <: AbstractParameterizedRegularization = norm(reg, x, λ(reg))
 
-prox!(reg::AbstractNestedRegularization, x, args...) = prox!(innerreg(reg), x, args...)
-norm(reg::AbstractNestedRegularization, x, args...) = norm(innerreg(reg), x, args...)
+#prox!(reg::AbstractNestedRegularization, x, args...) = prox!(innerreg(reg), x, args...)
+#norm(reg::AbstractNestedRegularization, x, args...) = norm(innerreg(reg), x, args...)

--- a/src/Regularization/PlugAndPlayRegularization.jl
+++ b/src/Regularization/PlugAndPlayRegularization.jl
@@ -11,18 +11,16 @@ The actual regularization term is indirectly defined by the learned proximal map
 
 # Keywords
 * `model`       - model applied to the image
-* `shape`       - dimensions of the image
 * `input_transform` - transform of image before `model`
 """
 struct PlugAndPlayRegularization{T, M, I} <: AbstractParameterizedRegularization{T}
     model::M
     λ::T
-    shape::Vector{Int}
     input_transform::I
     ignoreIm::Bool
-    PlugAndPlayRegularization(λ::T; model::M, shape, input_transform::I=RegularizedLeastSquares.MinMaxTransform, ignoreIm = false, kargs...) where {T, M, I} = new{T, M, I}(model, λ, shape, input_transform, ignoreIm)
+    PlugAndPlayRegularization(λ::T; model::M, input_transform::I=RegularizedLeastSquares.MinMaxTransform, ignoreIm = false, kargs...) where {T<:Number, M, I} = new{T, M, I}(model, λ, input_transform, ignoreIm)
 end
-PlugAndPlayRegularization(model, shape; kwargs...) = PlugAndPlayRegularization(one(Float32); kwargs..., model = model, shape = shape)
+PlugAndPlayRegularization(model; kwargs...) = PlugAndPlayRegularization(one(Float32); kwargs..., model = model)
 
 function prox!(self::PlugAndPlayRegularization, x::AbstractArray{Tc}, λ::T) where {T, Tc <: Complex{T}}
     out = real.(x)
@@ -43,8 +41,6 @@ function prox!(self::PlugAndPlayRegularization, x::AbstractArray{T}, λ::T) wher
       end
 
     out = copy(x)
-    out = reshape(out, self.shape...)
-
     tf = self.input_transform(out)
 
     out = RegularizedLeastSquares.transform(tf, out)

--- a/src/Regularization/TransformedRegularization.jl
+++ b/src/Regularization/TransformedRegularization.jl
@@ -26,12 +26,25 @@ end
 innerreg(reg::TransformedRegularization) = reg.reg
 
 function prox!(reg::TransformedRegularization, x::AbstractArray, args...)
+  shape = size(x)
+  z = reg.trafo * vec(x)
+  result = prox!(reg.reg, reshape(z, shape), args...)
+  x[:] = adjoint(reg.trafo) * result
+  return x
+end
+function prox!(reg::TransformedRegularization, x::AbstractVector, args...)
 	z = reg.trafo * x
   result = prox!(reg.reg, z, args...)
 	x[:] = adjoint(reg.trafo) * result
   return x
 end
 function norm(reg::TransformedRegularization, x::AbstractArray, args...)
+  shape = size(x)
+  z = reg.trafo * vec(x) 
+  result = norm(reg.reg, reshape(z, shape), args...)
+  return result
+end
+function norm(reg::TransformedRegularization, x::AbstractVector, args...)
   z = reg.trafo * x 
   result = norm(reg.reg, z, args...)
   return result

--- a/src/proximalMaps/ProxLLR.jl
+++ b/src/proximalMaps/ProxLLR.jl
@@ -15,13 +15,13 @@ Regularization term implementing the proximal map for locally low rank (LLR) reg
 """
 struct LLRRegularization{T, N, TI} <: AbstractParameterizedRegularization{T} where {N, TI<:Integer}
   λ::T
-  shape::NTuple{N,TI}
+  dims::Union{TI, NTuple{N, TI}}
   blockSize::NTuple{N,TI}
   randshift::Bool
   L::Int64
 end
-LLRRegularization(λ;  shape::NTuple{N,TI}, blockSize::NTuple{N,TI} = ntuple(_ -> 2, N), randshift::Bool = true, L::Int64 = 1, kargs...) where {N,TI<:Integer} =
- LLRRegularization(λ, shape, blockSize, randshift, L)
+LLRRegularization(λ; dims, blockSize::NTuple{N,TI} = ntuple(_ -> 2, N), randshift::Bool = true, L::Int64 = 1, kargs...) where {N,TI<:Integer} =
+ LLRRegularization(λ, dims, blockSize, randshift, L)
 
 """
     prox!(reg::LLRRegularization, x, λ)
@@ -29,7 +29,7 @@ LLRRegularization(λ;  shape::NTuple{N,TI}, blockSize::NTuple{N,TI} = ntuple(_ -
 performs the proximal map for LLR regularization using singular-value-thresholding
 """
 function prox!(reg::LLRRegularization{TR, N, TI}, x::AbstractArray{Tc}, λ::T) where {TR, N, TI, T, Tc <: Union{T, Complex{T}}}
-    shape = reg.shape
+    shape = size(x)
     blockSize = reg.blockSize
     randshift = reg.randshift
     x = reshape(x, tuple(shape..., length(x) ÷ prod(shape)))
@@ -92,8 +92,8 @@ end
 
 returns the value of the LLR-regularization term.
 """
-function norm(reg::LLRRegularization, x::Vector{Tc}, λ::T) where {T, Tc <: Union{T, Complex{T}}}
-    shape = reg.shape
+function norm(reg::LLRRegularization, x::AbstractArray{Tc}, λ::T) where {T, Tc <: Union{T, Complex{T}}}
+    shape = size(x)
     blockSize = reg.blockSize
     randshift = reg.randshift
     L = reg.L

--- a/src/proximalMaps/ProxNuclear.jl
+++ b/src/proximalMaps/ProxNuclear.jl
@@ -14,17 +14,16 @@ Regularization term implementing the proximal map for singular value soft-thresh
 """
 struct NuclearRegularization{T} <: AbstractParameterizedRegularization{T}
   λ::T
-  svtShape::NTuple
+  NuclearRegularization(λ::T; kargs...)  where T = new{T}(λ)
 end
-NuclearRegularization(λ; svtShape::NTuple=[], kargs...) = NuclearRegularization(λ, svtShape)
 
 """
     prox!(reg::NuclearRegularization, x, λ)
 
 performs singular value soft-thresholding - i.e. the proximal map for the nuclear norm regularization.
 """
-function prox!(reg::NuclearRegularization, x::Vector{Tc}, λ::T) where {T, Tc <: Union{T, Complex{T}}}
-  U,S,V = svd(reshape(x, reg.svtShape))
+function prox!(reg::NuclearRegularization, x::AbstractArray{Tc}, λ::T) where {T, Tc <: Union{T, Complex{T}}}
+  U,S,V = svd(x)
   prox!(L1Regularization, S, λ)
   x[:] = vec(U*Matrix(Diagonal(S))*V')
   return x
@@ -35,7 +34,7 @@ end
 
 returns the value of the nuclear norm regularization term.
 """
-function norm(reg::NuclearRegularization, x::Vector{Tc}, λ::T) where {T, Tc <: Union{T, Complex{T}}}
-  U,S,V = svd( reshape(x, reg.svtShape) )
+function norm(reg::NuclearRegularization, x::AbstractArray{Tc}, λ::T) where {T, Tc <: Union{T, Complex{T}}}
+  U,S,V = svd(x)
   return λ*norm(S,1)
 end

--- a/src/proximalMaps/ProxProj.jl
+++ b/src/proximalMaps/ProxProj.jl
@@ -5,12 +5,12 @@ struct ProjectionRegularization <: AbstractProjectionRegularization
 end
 ProjectionRegularization(; projFunc::Function=x->x, kargs...) = ProjectionRegularization(projFunc)
 
-function prox!(reg::ProjectionRegularization, x::Vector{Tc}) where {T, Tc <: Union{T, Complex{T}}}
+function prox!(reg::ProjectionRegularization, x::AbstractArray{Tc}) where {T, Tc <: Union{T, Complex{T}}}
   x[:] = reg.projFunc(x)
   return x
 end
 
-function norm(reg::ProjectionRegularization, x::Vector{Tc}) where {T, Tc <: Union{T, Complex{T}}}
+function norm(reg::ProjectionRegularization, x::AbstractArray{Tc}) where {T, Tc <: Union{T, Complex{T}}}
   y = copy(x)
   y[:] = prox!(reg, y)
   if y != x

--- a/src/proximalMaps/ProxReal.jl
+++ b/src/proximalMaps/ProxReal.jl
@@ -13,7 +13,7 @@ end
 
 enforce realness of solution `x`.
 """
-function prox!(::RealRegularization, x::Vector{T}) where T
+function prox!(::RealRegularization, x::AbstractArray{T}) where T
   enfReal!(x)
   return x
 end
@@ -23,7 +23,7 @@ end
 
 returns the value of the characteristic function of real, Real numbers.
 """
-function norm(reg::RealRegularization, x::Vector{T}) where T
+function norm(reg::RealRegularization, x::AbstractArray{T}) where T
   y = copy(x)
   prox!(reg, y)
   if y != x


### PR DESCRIPTION
This PR moves the shape keyword from various regularization terms into the solvers. Each solver defines a default shape which is essentially just the "default" vector derived from the operator. Before each `prox!` is being invoked the solver reshapes the solution according to the shape field.

During this PR we can also try to homogenize the reg. keywords related to the shape/dims.

I am not 100% sure yet if this is the correct way to go. On the one hand it makes constructing the reg. terms easier and removes individual `reshape` calls. On the other hand certain reg. terms do require `vec(x)` for example to apply a linear operator, so we added new `reshapes`.

We also have different default behaviours for reg. terms. For example previously the TV reg. had a `shape` and a `dims` term, which defaulted to all dimensions. Now we can't easily give a default here, since we don't have the shape information during the construction, only during the `prox!` call. As a test I played around with `nothing` as a default and special logic. I think if we stick with it we should move to a new default, which just follows the solver default of assuming just one dimension.