### PR TITLE
Issue warning when filtering `kwargs`

### DIFF
--- a/src/RegularizedLeastSquares.jl
+++ b/src/RegularizedLeastSquares.jl
@@ -239,6 +239,19 @@ See also [`isapplicable`](@ref), [`linearSolverList`](@ref).
 """
 applicableSolverList(args...) = filter(solver -> isapplicable(solver, args...), linearSolverListReal())
 
+function filterKwargs(T::Type, kwargs)
+  table = methods(T)
+  keywords = union(Base.kwarg_decl.(table)...)
+  filtered = filter(in(keywords), keys(kwargs))
+
+  if length(filtered) < length(kwargs)
+    filteredout = filter(!in(keywords), keys(kwargs))
+    @warn "The following arguments were passed but filtered out: $(join(filteredout, ", ")). Please watch closely if this introduces unexpexted behaviour in your code."
+  end
+
+  return [key=>kwargs[key] for key in filtered]
+end
+
 """
     createLinearSolver(solver::AbstractLinearSolver, A; kargs...)
 
@@ -247,18 +260,12 @@ regularized linear systems. All solvers return an approximate solution to Ax = b
 
 TODO: give a hint what solvers are available
 """
-function createLinearSolver(solver::Type{T}, A; kargs...) where {T<:AbstractLinearSolver}
-  table = methods(T)
-  keywords = union(Base.kwarg_decl.(table)...)
-  filtered = filter(in(keywords), keys(kargs))
-  return solver(A; [key=>kargs[key] for key in filtered]...)
+function createLinearSolver(solver::Type{T}, A; kwargs...) where {T<:AbstractLinearSolver}
+  return solver(A; filterKwargs(T, kwargs)...)
 end
 
-function createLinearSolver(solver::Type{T}; AHA, kargs...) where {T<:AbstractLinearSolver}
-  table = methods(T)
-  keywords = union(Base.kwarg_decl.(table)...)
-  filtered = filter(in(keywords), keys(kargs))
-  return solver(; [key=>kargs[key] for key in filtered]..., AHA = AHA)
+function createLinearSolver(solver::Type{T}; AHA, kwargs...) where {T<:AbstractLinearSolver}
+  return solver(; filterKwargs(T, kwargs)..., AHA = AHA)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using RegularizedLeastSquares, LinearAlgebra, RegularizedLeastSquares.LinearOper
 using Random, Test
 using FFTW
 
+include("testCreation.jl")
 include("testKaczmarz.jl")
 include("testProxMaps.jl")
 include("testSolvers.jl")

--- a/test/testCreation.jl
+++ b/test/testCreation.jl
@@ -1,0 +1,3 @@
+@testset "Creation of solvers" begin
+  @test_logs (:warn, Regex("The following arguments were passed but filtered out: testKwarg*")) createLinearSolver(Kaczmarz, zeros(42, 42), testKwarg=1337)
+end


### PR DESCRIPTION
When checking why the standard Kaczmarz is not using some keyword arguments (#80) I found that issueing a warning when filtering `kwargs` might be helpful.