### PR TITLE
Allow the use of fully overlapping blocks for LLR

### DIFF
--- a/src/proximalMaps/ProxLLR.jl
+++ b/src/proximalMaps/ProxLLR.jl
@@ -9,7 +9,7 @@ Regularization term implementing the proximal map for locally low rank (LLR) reg
 * `λ`                  - regularization paramter
 
 # Keywords
-* `shape::Tuple{Int}`         - dimensions of the image
+* `shape::Tuple{Int}`            - dimensions of the image
 * `blockSize::Tuple{Int}=(2,2)`  - size of patches to perform singular value thresholding on
 * `randshift::Bool=true`         - randomly shifts the patches to ensure translation invariance
 * `fullyOverlapping::Bool=false` - choose between fully overlapping block or non-overlapping blocks


### PR DESCRIPTION
The option to use fully overlapping blocks for LLR was inaccessible since prox! used non-overlapping blocks as a default. I made a wrapper function that now either calls the overlapping or non-overlapping proximal operator. Merging the two functions in one seemed messy since the overlapping case needs additional allocations which are not needed in the non-overlapping case. 

To avoid a lot of repeated code, I changed the implementation of the fully overlapping function to call proxLLRNonOverlapping!. I didn't investigate if this makes a difference in the computation time. 

Further, the norm is not implemented for fully overlapping blocks since it seems to only work for 2D patches currently. I remarked as much in the docstring. 

Best, 
Sebastian