### PR TITLE
Small fixes

### DIFF
--- a/src/CGNR.jl
+++ b/src/CGNR.jl
@@ -81,7 +81,7 @@ function CGNR(A
 
 
   return CGNR(A, AHA,
-    L2, other, x, x₀, pl, vl, αl, βl, ζl, iterations, relTol, 0.0, normalizeReg)
+    L2, other, x, x₀, pl, vl, αl, βl, ζl, iterations, Float64(relTol), 0.0, normalizeReg)
 end
 
 """

--- a/src/proximalMaps/ProxL1.jl
+++ b/src/proximalMaps/ProxL1.jl
@@ -16,7 +16,7 @@ end
 performs soft-thresholding - i.e. proximal map for the Lasso problem.
 """
 function prox!(::L1Regularization, x::AbstractArray{Tc}, λ::T) where {T, Tc <: Union{T, Complex{T}}}
-  ε = eps(T)
+  ε = eps(typeof(λ))
   x .= max.((abs.(x).-λ),0) .* (x.+ε)./(abs.(x).+ε)
   return x
 end


### PR DESCRIPTION
@nHackel I had to fix some things on Julia 1.10 to get L1 regularization and CGNR running. I am not sure why `T` does not exist in the context but using `typeof` should be optimized away so this should be equivalent.