### PR TITLE
State-based multi-threading

### DIFF
--- a/src/ADMM.jl
+++ b/src/ADMM.jl
@@ -140,7 +140,7 @@ function ADMM(A
   return ADMM(A, reg, regTrafo, proj, AHA, precon, normalizeReg, vary_rho, verbose, iterations, iterationsCG, state)
 end
 
-function init!(solver::ADMM, state::ADMMState{rT, rvecT, vecT}, b::otherT; kwargs...) where {rT, rvecT, vecT, otherT}
+function init!(solver::ADMM, state::ADMMState{rT, rvecT, vecT}, b::otherT; kwargs...) where {rT, rvecT, vecT, otherT <: AbstractVector}
   x    = similar(b, size(state.x)...)
   xᵒˡᵈ = similar(b, size(state.xᵒˡᵈ)...)
   β    = similar(b, size(state.β)...)
@@ -165,7 +165,7 @@ end
 
 (re-) initializes the ADMM iterator
 """
-function init!(solver::ADMM, state::ADMMState{rT, rvecT, vecT}, b::vecT; x0 = 0) where {rT, rvecT, vecT}
+function init!(solver::ADMM, state::ADMMState{rT, rvecT, vecT}, b::vecT; x0 = 0) where {rT, rvecT, vecT <: AbstractVector}
   state.x .= x0
 
   # right hand side for the x-update
@@ -202,7 +202,7 @@ solverconvergence(state::ADMMState) = (; :primal => state.rᵏ, :dual => state.s
 
 performs one ADMM iteration.
 """
-function iterate(solver::ADMM, state::S = solver.state) where S <: AbstractSolverState{<:ADMM}
+function iterate(solver::ADMM, state::ADMMState)
   done(solver, state) && return nothing
   solver.verbose && println("Outer ADMM Iteration #$iteration")
 

--- a/src/CGNR.jl
+++ b/src/CGNR.jl
@@ -131,7 +131,7 @@ end
 
 initCGNR(x₀, A, b) = mul!(x₀, adjoint(A), b)
 #initCGNR(x₀, prod::ProdOp{T, <:WeightingOp, matT}, b) where {T, matT} = mul!(x₀, adjoint(prod.B), b)
-initCGNR(x₀, ::Nothing, b) = x₀ .= one(eltype(x₀))
+initCGNR(x₀, ::Nothing, b) = x₀ .= b
 
 solverconvergence(state::CGNRState) = (; :residual => norm(state.x₀))
 

--- a/src/CGNR.jl
+++ b/src/CGNR.jl
@@ -88,7 +88,7 @@ function CGNR(A
   return CGNR(A, AHA, L2, other, normalizeReg, iterations, state)
 end
 
-function init!(solver::CGNR, state::CGNRState{T, Tc, vecTc}, b::otherTc; kwargs...) where {T, Tc, vecTc, otherTc}
+function init!(solver::CGNR, state::CGNRState{T, Tc, vecTc}, b::otherTc; kwargs...) where {T, Tc, vecTc, otherTc <: AbstractVector{Tc}}
   x = similar(b, size(state.x)...)
   x₀ = similar(b, size(state.x₀)...)
   pl = similar(b, size(state.pl)...)
@@ -104,7 +104,7 @@ end
 
 (re-) initializes the CGNR iterator
 """
-function init!(solver::CGNR, state::CGNRState{T, Tc, vecTc}, b::vecTc; x0 = 0) where {T, Tc <: Union{T, Complex{T}}, vecTc<:AbstractArray{Tc}}
+function init!(solver::CGNR, state::CGNRState{T, Tc, vecTc}, b::vecTc; x0 = 0) where {T, Tc <: Union{T, Complex{T}}, vecTc<:AbstractVector{Tc}}
   state.pl .= 0     #temporary vector
   state.vl .= 0     #temporary vector
   state.αl  = 0     #temporary scalar
@@ -140,7 +140,7 @@ solverconvergence(state::CGNRState) = (; :residual => norm(state.x₀))
 
 performs one CGNR iteration.
 """
-function iterate(solver::CGNR, state=solver.state)
+function iterate(solver::CGNR, state::CGNRState)
   if done(solver, state)
     for r in solver.constr
       prox!(r, state.x)

--- a/src/Direct.jl
+++ b/src/Direct.jl
@@ -41,19 +41,19 @@ function DirectSolver(A; reg::Vector{<:AbstractRegularization} = [L2Regularizati
   return DirectSolver(A, L2, normalizeReg, other, DirectSolverState(x, b))
 end
 
-function init!(solver::DirectSolver, state::DirectSolverState{vecT}, b::otherT; kwargs...) where {vecT, otherT}
+function init!(solver::DirectSolver, state::DirectSolverState{vecT}, b::otherT; kwargs...) where {vecT, otherT <: AbstractVector}
   x = similar(b, size(state.x)...)
   bvecT = similar(b, size(state.b)...)
   solver.state = DirectSolverState(x, bvecT)
   init!(solver, solver.state, b; kwargs...)
 end
-function init!(solver::DirectSolver, state::DirectSolverState{vecT}, b::vecT; x0=0) where vecT
+function init!(solver::DirectSolver, state::DirectSolverState{vecT}, b::vecT; x0=0) where vecT <: AbstractVector
   solver.l2 = normalize(solver, solver.normalizeReg, solver.l2, solver.A, b)
   state.b .= b
   state.x .= x0
 end
 
-function iterate(solver::DirectSolver, state = solver.state)
+function iterate(solver::DirectSolver, state::DirectSolverState)
   A = solver.A
   λ_ = λ(solver.l2)
   lufact = lu(A'*A .+ λ_)
@@ -138,18 +138,18 @@ function PseudoInverse(A::AbstractMatrix, x, b, l2, norm, proj)
   return PseudoInverse(temp, l2, norm, proj, DirectSolverState(x, b))
 end
 
-function init!(solver::PseudoInverse, state::DirectSolverState{vecT}, b::otherT; kwargs...) where {vecT, otherT}
+function init!(solver::PseudoInverse, state::DirectSolverState{vecT}, b::otherT; kwargs...) where {vecT, otherT <: AbstractVector}
   x = similar(b, size(state.x)...)
   bvecT = similar(b, size(state.b)...)
   solver.state = DirectSolverState(x, bvecT)
   init!(solver, solver.state, b; kwargs...)
 end
-function init!(solver::PseudoInverse, state::DirectSolverState{vecT}, b::vecT; x0=0) where vecT
+function init!(solver::PseudoInverse, state::DirectSolverState{vecT}, b::vecT; x0=0) where vecT <: AbstractVector
   solver.l2 = normalize(solver, solver.normalizeReg, solver.l2, solver.svd, b)
   state.b .= b
 end
 
-function iterate(solver::PseudoInverse, state = solver.state)
+function iterate(solver::PseudoInverse, state::DirectSolverState)
   # Inversion by using the pseudoinverse of the SVD
   svd = solver.svd
 

--- a/src/FISTA.jl
+++ b/src/FISTA.jl
@@ -91,7 +91,7 @@ function FISTA(A
   return FISTA(A, AHA, reg[1], other, normalizeReg, verbose, restart, iterations, state)
 end
 
-function init!(solver::FISTA, state::FISTAState{rT, vecT}, b::otherT; kwargs...) where {rT, vecT, otherT}
+function init!(solver::FISTA, state::FISTAState{rT, vecT}, b::otherT; kwargs...) where {rT, vecT, otherT <: AbstractVector}
   x = similar(b, size(state.x)...)
   x₀ = similar(b, size(state.x₀)...)
   xᵒˡᵈ = similar(b, size(state.xᵒˡᵈ)...)
@@ -107,7 +107,7 @@ end
 
 (re-) initializes the FISTA iterator
 """
-function init!(solver::FISTA, state::FISTAState{rT, vecT}, b::vecT; x0 = 0, theta=1) where {rT, vecT}
+function init!(solver::FISTA, state::FISTAState{rT, vecT}, b::vecT; x0 = 0, theta=1) where {rT, vecT <: AbstractVector}
   if solver.A === nothing
     state.x₀ .= b
   else
@@ -136,7 +136,7 @@ solverconvergence(state::FISTAState) = (; :residual => norm(state.res))
 
 performs one fista iteration.
 """
-function iterate(solver::FISTA, state = solver.state)
+function iterate(solver::FISTA, state::FISTAState)
   if done(solver, state) return nothing end
 
   # momentum / Nesterov step

--- a/src/Kaczmarz.jl
+++ b/src/Kaczmarz.jl
@@ -164,9 +164,9 @@ end
 
 
 function solversolution(solver::Kaczmarz{matT, RN}) where {matT, R<:L2Regularization{<:AbstractVector}, RN <: Union{R, AbstractNestedRegularization{<:R}}}
-  return solver.state.x .* (1 ./ sqrt.(λ(solver.L2)))
+  return solversolution(solver.state) .* (1 ./ sqrt.(λ(solver.L2)))
 end
-solversolution(solver::Kaczmarz) = solver.state.x
+solversolution(solver::Kaczmarz) = solversolution(solver.state)
 solverconvergence(state::KaczmarzState) = (; :residual => norm(state.vl))
 
 function iterate(solver::Kaczmarz, state::KaczmarzState)

--- a/src/Kaczmarz.jl
+++ b/src/Kaczmarz.jl
@@ -110,7 +110,7 @@ function Kaczmarz(A
                   Int64(seed), normalizeReg, iterations, state)
 end
 
-function init!(solver::Kaczmarz, state::KaczmarzState{T, vecT}, b::otherT; kwargs...) where {T, vecT, otherT}
+function init!(solver::Kaczmarz, state::KaczmarzState{T, vecT}, b::otherT; kwargs...) where {T, vecT, otherT <: AbstractVector}
   u = similar(b, size(state.u)...)
   x = similar(b, size(state.x)...)
   vl = similar(b, size(state.vl)...)
@@ -125,7 +125,7 @@ end
 
 (re-) initializes the Kacmarz iterator
 """
-function init!(solver::Kaczmarz, state::KaczmarzState{T, vecT}, b::vecT; x0 = 0) where {T, vecT}
+function init!(solver::Kaczmarz, state::KaczmarzState{T, vecT}, b::vecT; x0 = 0) where {T, vecT <: AbstractVector}
   λ_prev = λ(solver.L2)
   solver.L2  = normalize(solver, solver.normalizeReg, solver.L2,  solver.A, b)
   solver.reg = normalize(solver, solver.normalizeReg, solver.reg, solver.A, b)
@@ -169,7 +169,7 @@ end
 solversolution(solver::Kaczmarz) = solver.state.x
 solverconvergence(state::KaczmarzState) = (; :residual => norm(state.vl))
 
-function iterate(solver::Kaczmarz, state = solver.state)
+function iterate(solver::Kaczmarz, state::KaczmarzState)
   if done(solver,state) return nothing end
 
   if solver.randomized

--- a/src/MultiThreading.jl
+++ b/src/MultiThreading.jl
@@ -1,4 +1,4 @@
-export SequentialState, MultiThreadingState
+export SequentialState, MultiThreadingState, prepareMultiStates
 abstract type AbstractMatrixSolverState{S} <: AbstractSolverState{S} end
 mutable struct SequentialState{S, ST <: AbstractSolverState{S}} <: AbstractMatrixSolverState{S}
   states::Vector{ST}
@@ -30,14 +30,14 @@ function prepareMultiStates(solver::AbstractLinearSolver, state::AbstractSolverS
 end
 prepareMultiStates(solver::AbstractLinearSolver, state::Union{SequentialState, MultiThreadingState}, b::AbstractMatrix) = prepareMultiStates(solver, first(state.states), b)
 
-function init!(solver::AbstractLinearSolver, state::Union{SequentialState, MultiThreadingState}, b::AbstractMatrix; kwargs...)
+function init!(solver::AbstractLinearSolver, state::AbstractMatrixSolverState, b::AbstractMatrix; kwargs...)
   for (i, s) in enumerate(state.states)
     init!(solver, s, b[:, i]; kwargs...)
   end
   state.active .= true
 end
 
-function iterate(solver::S, state::Union{SequentialState, MultiThreadingState}) where {S <: AbstractLinearSolver}
+function iterate(solver::S, state::AbstractMatrixSolverState) where {S <: AbstractLinearSolver}
   activeIdx = findall(state.active)
   if isempty(activeIdx)
     return nothing

--- a/src/MultiThreading.jl
+++ b/src/MultiThreading.jl
@@ -1,0 +1,68 @@
+export SequentialState, MultiThreadingState
+abstract type AbstractMatrixSolverState{S} <: AbstractSolverState{S} end
+mutable struct SequentialState{S, ST <: AbstractSolverState{S}} <: AbstractMatrixSolverState{S}
+  states::Vector{ST}
+  active::Vector{Bool}
+  SequentialState(states::Vector{ST}) where {S, ST <: AbstractSolverState{S}} = new{S, ST}(states, fill(true, length(states)))
+end
+
+mutable struct MultiThreadingState{S, ST <: AbstractSolverState{S}} <: AbstractMatrixSolverState{S}
+  states::Vector{ST}
+  active::Vector{Bool}
+  MultiThreadingState(states::Vector{ST}) where {S, ST <: AbstractSolverState{S}} = new{S, ST}(states, fill(true, length(states)))
+end
+
+function init!(solver::AbstractLinearSolver, state::AbstractSolverState, b::AbstractMatrix; scheduler = SequentialState, kwargs...)
+  states = prepareMultiStates(solver, state, b)
+  multiState = scheduler(states)
+  solver.state = multiState
+  init!(solver, multiState, b; kwargs...)
+end
+function init!(solver::AbstractLinearSolver, state::AbstractMatrixSolverState, b::AbstractVector; kwargs...)
+  singleState = first(state.states)
+  solver.state = singleState
+  init!(solver, singleState, b; kwargs...)
+end
+
+function prepareMultiStates(solver::AbstractLinearSolver, state::AbstractSolverState, b::AbstractMatrix)
+  states = [deepcopy(state) for _ in 1:size(b, 2)]
+  return states
+end
+prepareMultiStates(solver::AbstractLinearSolver, state::Union{SequentialState, MultiThreadingState}, b::AbstractMatrix) = prepareMultiStates(solver, first(state.states), b)
+
+function init!(solver::AbstractLinearSolver, state::Union{SequentialState, MultiThreadingState}, b::AbstractMatrix; kwargs...)
+  for (i, s) in enumerate(state.states)
+    init!(solver, s, b[:, i]; kwargs...)
+  end
+  state.active .= true
+end
+
+function iterate(solver::S, state::Union{SequentialState, MultiThreadingState}) where {S <: AbstractLinearSolver}
+  activeIdx = findall(state.active)
+  if isempty(activeIdx)
+    return nothing
+  end
+  return iterate(solver, state, activeIdx)
+end
+
+function iterate(solver::AbstractLinearSolver, state::SequentialState, activeIdx)
+  for i in activeIdx
+    res = iterate(solver, state.states[i])
+    if isnothing(res)
+      state.active[i] = false
+    end
+  end
+  return state.active, state
+end
+
+function iterate(solver::AbstractLinearSolver, state::MultiThreadingState, activeIdx)
+  Threads.@threads for i in activeIdx
+    res = iterate(solver, state.states[i])
+    if isnothing(res)
+      state.active[i] = false
+    end
+  end
+  return state.active, state
+end
+
+solversolution(state::Union{SequentialState, MultiThreadingState}) = mapreduce(solversolution, hcat, state.states)

--- a/src/MultiThreading.jl
+++ b/src/MultiThreading.jl
@@ -65,4 +65,4 @@ function iterate(solver::AbstractLinearSolver, state::MultiThreadingState, activ
   return state.active, state
 end
 
-solversolution(state::Union{SequentialState, MultiThreadingState}) = mapreduce(solversolution, hcat, state.states)
+solversolution(state::AbstractMatrixSolverState) = mapreduce(solversolution, hcat, state.states)

--- a/src/OptISTA.jl
+++ b/src/OptISTA.jl
@@ -104,7 +104,7 @@ function OptISTA(A
   return OptISTA(A, AHA, reg[1], other, normalizeReg, verbose, iterations, state)
 end
 
-function init!(solver::OptISTA, state::OptISTAState{rT, vecT}, b::otherT; kwargs...) where {rT, vecT, otherT}
+function init!(solver::OptISTA, state::OptISTAState{rT, vecT}, b::otherT; kwargs...) where {rT, vecT, otherT <: AbstractVector}
   x = similar(b, size(state.x)...)
   x₀ = similar(b, size(state.x₀)...)
   y = similar(b, size(state.y)...)
@@ -125,7 +125,7 @@ end
 
 (re-) initializes the OptISTA iterator
 """
-function init!(solver::OptISTA, state::OptISTAState{rT, vecT}, b::vecT; x0 = 0, θ=1) where {rT, vecT}
+function init!(solver::OptISTA, state::OptISTAState{rT, vecT}, b::vecT; x0 = 0, θ=1) where {rT, vecT <: AbstractVector}
   if solver.A === nothing
     state.x₀ .= b
   else
@@ -161,7 +161,7 @@ solverconvergence(state::OptISTAState) = (; :residual => norm(state.res))
 
 performs one OptISTA iteration.
 """
-function iterate(solver::OptISTA, state::OptISTAState = solver.state)
+function iterate(solver::OptISTA, state::OptISTAState)
   if done(solver, state) return nothing end
 
   # inertial parameters

--- a/src/POGM.jl
+++ b/src/POGM.jl
@@ -113,7 +113,7 @@ function POGM(A
   return POGM(A, AHA, reg[1], other, normalizeReg, verbose, restart, iterations, state)
 end
 
-function init!(solver::POGM, state::POGMState{rT, vecT}, b::otherT; kwargs...) where {rT, vecT, otherT}
+function init!(solver::POGM, state::POGMState{rT, vecT}, b::otherT; kwargs...) where {rT, vecT, otherT <: AbstractVector}
   x = similar(b, size(state.x)...)
   x₀ = similar(b, size(state.x₀)...)
   xᵒˡᵈ = similar(b, size(state.xᵒˡᵈ)...)
@@ -135,7 +135,7 @@ end
 
 (re-) initializes the POGM iterator
 """
-function init!(solver::POGM, state::POGMState{rT, vecT}, b::vecT; x0 = 0, theta=1) where {rT, vecT}
+function init!(solver::POGM, state::POGMState{rT, vecT}, b::vecT; x0 = 0, theta=1) where {rT, vecT <: AbstractVector}
   if solver.A === nothing
     state.x₀ .= b
   else
@@ -170,7 +170,7 @@ solverconvergence(state::POGMState) = (; :residual => norm(state.res))
 
 performs one POGM iteration.
 """
-function iterate(solver::POGM, state = solver.state)
+function iterate(solver::POGM, state::POGMState)
   if done(solver, state)
     return nothing
   end

--- a/src/RegularizedLeastSquares.jl
+++ b/src/RegularizedLeastSquares.jl
@@ -99,13 +99,13 @@ The keyword `callbacks` allows you to pass a (vector of) callable objects that t
 
 See also [`StoreSolutionCallback`](@ref), [`StoreConvergenceCallback`](@ref), [`CompareSolutionCallback`](@ref) for a number of provided callback options.
 """
-function solve!(solver::AbstractLinearSolver, b; x0 = 0, callbacks = (_, _) -> nothing)
+function solve!(solver::AbstractLinearSolver, b; callbacks = (_, _) -> nothing, kwargs...)
   if !(callbacks isa Vector)
     callbacks = [callbacks]
   end
 
 
-  init!(solver, b; x0)
+  init!(solver, b; kwargs...)
   foreach(cb -> cb(solver, 0), callbacks)
 
   for (iteration, _) = enumerate(solver)
@@ -129,7 +129,7 @@ end
 """
 solve!(cb, solver::AbstractLinearSolver, b; kwargs...) = solve!(solver, b; kwargs..., callbacks = cb)
 
-
+include("MultiThreading.jl")
 
 export AbstractRowActionSolver
 abstract type AbstractRowActionSolver <: AbstractLinearSolver end
@@ -159,7 +159,13 @@ export solversolution, solverconvergence, solverstate
 
 Return the current solution of the solver
 """
-solversolution(solver::AbstractLinearSolver) = solverstate(solver).x
+solversolution(solver::AbstractLinearSolver) = solversolution(solverstate(solver))
+"""
+    solversolution(state::AbstractSolverState)
+
+Return the current solution of the solver's state
+"""
+solversolution(state::AbstractSolverState) = state.x
 """
     solverconvergence(solver::AbstractLinearSolver)
 

--- a/src/RegularizedLeastSquares.jl
+++ b/src/RegularizedLeastSquares.jl
@@ -171,6 +171,7 @@ solverstate(solver::AbstractLinearSolver) = solver.state
 solverconvergence(solver::AbstractLinearSolver) = solverconvergence(solverstate(solver))
 
 init!(solver::AbstractLinearSolver, b; kwargs...) = init!(solver, solverstate(solver), b; kwargs...)
+iterate(solver::AbstractLinearSolver) = iterate(solver, solverstate(solver))
 
 include("Utils.jl")
 include("Kaczmarz.jl")

--- a/src/SplitBregman.jl
+++ b/src/SplitBregman.jl
@@ -143,7 +143,7 @@ function SplitBregman(A
   return SplitBregman(A,reg,regTrafo,proj,AHA,precon,normalizeReg,verbose,iterations,iterationsInner,iterationsCG,state)
 end
 
-function init!(solver::SplitBregman, state::SplitBregmanState{rT, rvecT, vecT}, b::otherT; kwargs...) where {rT, rvecT, vecT, otherT}
+function init!(solver::SplitBregman, state::SplitBregmanState{rT, rvecT, vecT}, b::otherT; kwargs...) where {rT, rvecT, vecT, otherT <: AbstractVector}
   y    = similar(b, size(state.y)...)
   x    = similar(b, size(state.x)...)
   β    = similar(b, size(state.β)...)
@@ -167,7 +167,7 @@ end
 
 (re-) initializes the SplitBregman iterator
 """
-function init!(solver::SplitBregman, state::SplitBregmanState{rT, rvecT, vecT}, b::vecT; x0 = 0) where {rT, rvecT, vecT}
+function init!(solver::SplitBregman, state::SplitBregmanState{rT, rvecT, vecT}, b::vecT; x0 = 0) where {rT, rvecT, vecT <: AbstractVector}
   state.x .= x0
 
   # right hand side for the x-update
@@ -201,7 +201,7 @@ end
 
 solverconvergence(state::SplitBregmanState) = (; :primal => state.rᵏ, :dual => state.sᵏ)
 
-function iterate(solver::SplitBregman, state=solver.state)
+function iterate(solver::SplitBregman, state::SplitBregmanState)
   if done(solver, state) return nothing end
   solver.verbose && println("SplitBregman Iteration #$(state.iteration) – Outer iteration $(state.iter_cnt)")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,5 @@ arrayTypes = areTypesDefined ? arrayTypes : [Array, JLArray]
   include("testProxMaps.jl")
   include("testSolvers.jl")
   include("testRegularization.jl")
+  include("testMultiThreading.jl")
 end

--- a/test/testMultiThreading.jl
+++ b/test/testMultiThreading.jl
@@ -1,0 +1,32 @@
+function testMultiThreadingSolver(; arrayType = Array, scheduler = MultiDataState)
+  A = rand(ComplexF32, 3, 2)
+  x = rand(ComplexF32, 2, 4)
+  b = A * x
+
+  solvers = [CGNR] # linearSolverList()
+  @testset "$(solvers[i])" for i = 1:length(solvers)
+    S = createLinearSolver(solvers[i], arrayType(A), iterations = 100)
+    
+    x_sequential = hcat([Array(solve!(S, arrayType(b[:, j]))) for j = 1:size(b, 2)]...)
+    @test x_sequential ≈ x rtol = 0.1
+    
+    x_approx = Array(solve!(S, arrayType(b), scheduler=scheduler))
+    @test x_approx ≈ x rtol = 0.1
+
+    # Does sequential/normal reco still works after multi-threading
+    x_vec = Array(solve!(S, arrayType(b[:, 1])))
+    @test x_vec ≈ x[:, 1] rtol = 0.1
+  end
+end
+
+@testset "Test MultiThreading Support" begin
+  for arrayType in arrayTypes
+    @testset "$arrayType" begin
+      for scheduler in [SequentialState, MultiThreadingState]
+        @testset "$scheduler" begin
+          testMultiThreadingSolver(; arrayType, scheduler)
+        end
+      end
+    end
+  end
+end

--- a/test/testMultiThreading.jl
+++ b/test/testMultiThreading.jl
@@ -3,7 +3,7 @@ function testMultiThreadingSolver(; arrayType = Array, scheduler = MultiDataStat
   x = rand(ComplexF32, 2, 4)
   b = A * x
 
-  solvers = [CGNR] # linearSolverList()
+  solvers = linearSolverList()
   @testset "$(solvers[i])" for i = 1:length(solvers)
     S = createLinearSolver(solvers[i], arrayType(A), iterations = 100)
     


### PR DESCRIPTION
So far RegularizedLeastSquares.jl offers support for two types of multi-threading which are both transparent to the package.

The highest-level of multi-threading is just when a user creates multiple solvers in parallel (potentially with different parameters):

```julia
Threads.@threads for (i, A) in enumerate(operators)
  solver = createLinearSolver(CGNR, A, iterations = ...)
  push!(results, solve!(solver, b[:, i]))
end
```
Then we also support low-level multi-threading within the linear operators given to the package. This is just completely transparent to us. MRIReco for example uses both of these multi-threading options (with `@floop` instead of the Threads version).

This PR takes advantage of the split between a solver and its state to add middle-level of multi-threading. This level of multi-threading applies the same solver (and its parameters) to multiple measurement vectors or rather a measurement matrix `B`.

Solvers and their state are currently defined as follows:

```julia
mutable struct Solver{matT, ...}
  A::matT
  # Other "static" fields
  state::AbstractSolverState{<:Solver}
end

mutable struct SolverState{T, tempT} <: AbstractSolverState{Solver}
  x::tempT
  rho::T
  # ...
  iteration::Int64
end
```

While both the solver and its state are mutable structs, the solver struct is intended to be immutable during a `solve!` call. This allows us to simply copy the state, initialize each state with a slice of `B` and then perform iterations on each state separately. Since the solver has an `AbstractSolverState` as a field, we can exchange this for a new state holding all the usual states for each  slice. While this is technically a type-instability, in the iterate method we always dispatch on the state-type too, so we are not affected by the type-instability in our hot-loops.

To make this feature optional and hackable to users, I've introduced a new keyword `scheduler` to the `solve!` call which gets passed on to the `init!` call if a user provides a measurement matrix. Scheduler defaults to a simple sequential implementation without multi-threading. Out of the box we also support multi-threading via `Threads.@threads` with `scheduler = MultiThreadingState`. The scheduler is treated like a callable that gets invoked with a copy of all necessary states. 

As an example I sketch how to implement a custom `@floop` scheduler:

```julia
# Struct definition, we track both the states and if they are still active. Since most solver have conv. criteria, they can finish at different iteration numbers
# Atm the generic functions expect the scheduler structs to have a `states` and `active` property.
mutable struct FloopState{S, ST <: AbstractSolverState{S}} <: AbstractMatrixSolverState{S}
  states::Vector{ST}
  active::Vector{Bool}
  FloopState(states::Vector{ST}) where {S, ST <: AbstractSolverState{S}} = new{S, ST}(states, fill(true, length(states)))
end

# To hook into the existing init! code we only have to supply a method that gets a copyable "vector" state. This will invoke our FloopState constructor with copies of the given state.
prepareMultiStates(solver::AbstractLinearSolver, state::FloopState, b::AbstractMatrix) = prepareMultiStates(solver, first(state.states), b)

# This iterate function is called with the idx of still active states
function iterate(solver::AbstractLinearSolver, state::FloopState, activeIdx)
  @floop for i in activeIdx
    res = iterate(solver, state.states[i])
    if isnothing(res)
      state.active[i] = false
    end
  end
  return state.active, state
end

# To call this we now simply have to do
solver = createLinearSolver(CGNR, A, ...)
solve!(solver, B; scheduler = FloopState)
```
A solver is also not locked into always doing multi-threading once it was passed a matrix. It seamlessly switches back to normal execution when given a vector.

Note that switching out the state as is done here, also allows one to specify special variants of a solver as is done in this [PR](https://github.com/MagneticParticleImaging/MPIReco.jl/pull/41).

Furthermore, we can also now specify special algorithms variants  that work directly on `B` and not slices of it. An example of this could be an implementation of Kaczmarz as described in [this work](https://iopscience.iop.org/article/10.1088/1361-6560/ad078d).