### PR TITLE
LLR_allocations

### DIFF
--- a/ext/RegularizedLeastSquaresCUDAExt/ProxLLR.jl
+++ b/ext/RegularizedLeastSquaresCUDAExt/ProxLLR.jl
@@ -1,6 +1,0 @@
-function RegularizedLeastSquares.proxLLRNonOverlapping!(reg::LLRRegularization{TR, N, TI}, x::Union{CuArray{T}, CuArray{Complex{T}}}, λ::T) where {TR, N, TI, T}
-    x_cpu = Array(x)
-    RegularizedLeastSquares.proxLLRNonOverlapping!(reg, x_cpu, λ)
-    copyto!(x, x_cpu)
-    return x
-end

--- a/ext/RegularizedLeastSquaresCUDAExt/RegularizedLeastSquaresCUDAExt.jl
+++ b/ext/RegularizedLeastSquaresCUDAExt/RegularizedLeastSquaresCUDAExt.jl
@@ -4,6 +4,5 @@ using RegularizedLeastSquares, RegularizedLeastSquares.LinearAlgebra, Regularize
 using CUDA, CUDA.CUSPARSE
 
 include("NormalizedRegularization.jl")
-include("ProxLLR.jl")
 
 end # module

--- a/ext/RegularizedLeastSquaresGPUArraysExt/ProxLLR.jl
+++ b/ext/RegularizedLeastSquaresGPUArraysExt/ProxLLR.jl
@@ -1,0 +1,6 @@
+function RegularizedLeastSquares.proxLLRNonOverlapping!(reg::LLRRegularization{TR, N, TI}, x::Union{AbstractGPUArray{T}, AbstractGPUArray{Complex{T}}}, λ::T) where {TR, N, TI, T}
+    x_cpu = Array(x)
+    RegularizedLeastSquares.proxLLRNonOverlapping!(reg, x_cpu, λ)
+    copyto!(x, x_cpu)
+    return x
+end

--- a/ext/RegularizedLeastSquaresGPUArraysExt/RegularizedLeastSquaresGPUArraysExt.jl
+++ b/ext/RegularizedLeastSquaresGPUArraysExt/RegularizedLeastSquaresGPUArraysExt.jl
@@ -6,6 +6,7 @@ using GPUArrays, KernelAbstractions
 include("Utils.jl")
 include("ProxTV.jl")
 include("ProxL21.jl")
+include("ProxLLR.jl")
 include("NormalizedRegularization.jl")
 include("Kaczmarz.jl")
 

--- a/src/proximalMaps/ProxLLR.jl
+++ b/src/proximalMaps/ProxLLR.jl
@@ -4,6 +4,7 @@ export LLRRegularization
     LLRRegularization
 
 Regularization term implementing the proximal map for locally low rank (LLR) regularization using singular-value-thresholding.
+Computation is always performed on the CPU. If the input is a GPU array, it is temporarily moved to the CPU.
 
 # Arguments
 * `λ`                  - regularization paramter
@@ -37,7 +38,7 @@ end
 """
     proxLLRNonOverlapping!(reg::LLRRegularization, x, λ)
 
-performs the proximal map for LLR regularization using singular-value-thresholding on non-overlapping blocks
+performs the proximal map for LLR regularization using singular-value-thresholding on non-overlapping blocks.
 """
 function proxLLRNonOverlapping!(reg::LLRRegularization{TR,N,TI}, x::Union{AbstractArray{T},AbstractArray{Complex{T}}}, λ::T) where {TR,N,TI,T}
     shape = reg.shape


### PR DESCRIPTION
In order to speed up the LLR calculation (non-overlapping), I made the following changes:

- replace `circshift` with `ShiftedArrays.circshift` for `randshift`. This saves a huge allocation. Unfortunately, it does not work on `CuArrays` (see below). 
- avoid an allocation if `blockSize` does not fit `shape`. 
- allocate in `xᴸᴸᴿ` only one block-matrix / task rather than one for each image block. This required switching from FLoops.jl to OhMyTask.jl, which provides the `@local` macro. 
- skip the SVD when all voxels in a block are zero, which can happen with ESPIRIT coil sensitivities. (minor improvements). 

These steps together halved the memory allocations, and the rest is virtually all allocated by the SVD. 

The old code worked on the GPU, though it was much slower compared to the CPU. For this reason, I figured it is OK if we sacrifice GPU support, and regain it by adding a wrapper that copies the data-array to the CPU, performs the SVD, and copies the final array back to the GPU. This is, by far, the fastest implementation I was able to come up with and I think there are some fundamental issues with making "many mid-sized SVDs" fast on the GPU. Currently, I implemented this only for CUDA, but I guess something similar can be done in the other extension for abstract GPUArrays?

Happy for feedback and a discussion on how to handle the GPU-stuff!
